### PR TITLE
fix(security): restrict MCP server CORS and MITM proxy bind address

### DIFF
--- a/src/main/mcp/mcp-server.ts
+++ b/src/main/mcp/mcp-server.ts
@@ -66,8 +66,21 @@ export async function initMCPServer(
 
   httpServer = createServer(
     async (req: IncomingMessage, res: ServerResponse) => {
-      // CORS
-      res.setHeader("Access-Control-Allow-Origin", "*");
+      // CORS — restrict to localhost origins only to prevent cross-origin attacks
+      const origin = req.headers.origin;
+      const isLocalOrigin =
+        !origin ||
+        /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
+
+      if (!isLocalOrigin) {
+        res.writeHead(403);
+        res.end("Forbidden");
+        return;
+      }
+
+      if (origin) {
+        res.setHeader("Access-Control-Allow-Origin", origin);
+      }
       res.setHeader(
         "Access-Control-Allow-Methods",
         "GET, POST, DELETE, OPTIONS",

--- a/src/main/proxy/mitm-proxy-server.ts
+++ b/src/main/proxy/mitm-proxy-server.ts
@@ -55,7 +55,7 @@ export class MitmProxyServer extends EventEmitter {
     });
 
     return new Promise((resolve, reject) => {
-      this.server!.listen(port, "0.0.0.0", () => {
+      this.server!.listen(port, "127.0.0.1", () => {
         this.port = port;
         console.log(`[MitmProxy] Listening on port ${port}`);
         resolve();


### PR DESCRIPTION
## Security Vulnerability Report

### Vulnerability 1: MCP Server Wildcard CORS (Critical)

**Type:** CORS Misconfiguration — Cross-Origin Data Theft  
**Severity:** Critical  
**Location:** `src/main/mcp/mcp-server.ts:70`

#### Description

The MCP HTTP server sets `Access-Control-Allow-Origin: *` with no authentication. Any website the user visits in *any* browser can send cross-origin requests to the local MCP server (default port 23816) and:

- **Read all captured HTTP requests** — including auth tokens, cookies, session data, passwords
- **Navigate the embedded browser** to arbitrary URLs (phishing, credential harvesting)
- **Start/stop capture sessions** and trigger AI analysis
- **Clear browser storage** (cookies, localStorage)

A malicious website only needs to know the port (which is hardcoded in the source) to fully exploit this.

#### Fix

Validate the `Origin` header and reject requests from non-localhost origins. Requests without an `Origin` header (from CLI tools, non-browser MCP clients) are still allowed. When a valid localhost origin is present, it's reflected back instead of using a wildcard.

---

### Vulnerability 2: MITM Proxy Bound to All Interfaces (High)

**Type:** Network Exposure  
**Severity:** High  
**Location:** `src/main/proxy/mitm-proxy-server.ts:58`

#### Description

The MITM proxy listens on `0.0.0.0` (all network interfaces), exposing it to every device on the local network. Any device on the same Wi-Fi or LAN segment can:

- Route their HTTP/HTTPS traffic through the proxy
- Have their HTTPS connections decrypted via the dynamically-issued certificates
- Have all their traffic (including credentials, API keys, private data) captured in the app's database

On shared or public networks, this is especially dangerous.

#### Fix

Bind to `127.0.0.1` instead of `0.0.0.0` so the proxy only accepts connections from the local machine.

---

### Impact

Without these fixes:
- **Any website** can steal all data captured by the analyzer (CORS vuln)
- **Any device on the LAN** can have its HTTPS traffic intercepted (bind address vuln)

Both vulnerabilities are silently exploitable with no user interaction beyond normal app usage.

---

Found by [Aeon](https://github.com/aaronjmars/aeon-aaron) — automated security scanner