### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/src/main/ai/llm-router.ts
+++ b/src/main/ai/llm-router.ts
@@ -70,7 +70,7 @@ export class LLMRouter {
     messages: ChatMessage[],
     onChunk?: (chunk: string) => void,
   ): Promise<LLMResponse> {
-    if (this.config.name === "anthropic") {
+    if (this.config.name === "anthropic" || this.config.name === "minimax") {
       return this.completeAnthropic(messages, onChunk);
     }
     if (this.config.apiType === "responses") {
@@ -90,7 +90,7 @@ export class LLMRouter {
     onChunk?: (chunk: string) => void,
     maxRounds = 10,
   ): Promise<LLMResponse> {
-    if (this.config.name === "anthropic") {
+    if (this.config.name === "anthropic" || this.config.name === "minimax") {
       return this.agenticLoopAnthropic(messages, tools, callTool, onChunk, maxRounds);
     }
     return this.agenticLoopOpenAI(messages, tools, callTool, onChunk, maxRounds);

--- a/src/renderer/components/settings/LLMSection.tsx
+++ b/src/renderer/components/settings/LLMSection.tsx
@@ -5,6 +5,7 @@ import type { LLMProviderConfig, LLMProviderType, OpenAIApiType } from '@shared/
 const defaultUrls: Record<LLMProviderType, string> = {
   openai: 'https://api.openai.com/v1',
   anthropic: 'https://api.anthropic.com/v1',
+  minimax: 'https://api.minimax.io/anthropic/v1',
   custom: '',
 }
 
@@ -47,7 +48,7 @@ export default function LLMSection() {
     const provider = value as LLMProviderType
     setName(provider)
     setBaseUrl(defaultUrls[provider])
-    if (provider === 'anthropic') {
+    if (provider === 'anthropic' || provider === 'minimax') {
       setApiType(undefined)
     } else if (!apiType) {
       setApiType('completions')
@@ -81,6 +82,7 @@ export default function LLMSection() {
           options={[
             { label: 'OpenAI', value: 'openai' },
             { label: 'Anthropic', value: 'anthropic' },
+            { label: 'MiniMax', value: 'minimax' },
             { label: 'Custom (OpenAI Compatible)', value: 'custom' },
           ]}
         />
@@ -123,7 +125,7 @@ export default function LLMSection() {
         <Input
           value={model}
           onChange={e => setModel(e.target.value)}
-          placeholder="gpt-4o / claude-sonnet-4-20250514 / ..."
+          placeholder="gpt-4o / claude-sonnet-4-20250514 / MiniMax-M2.7 / ..."
         />
       </div>
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -168,7 +168,7 @@ export interface UpdateStatus {
 
 // ---- LLM Provider Config ----
 
-export type LLMProviderType = "openai" | "anthropic" | "custom";
+export type LLMProviderType = "openai" | "anthropic" | "minimax" | "custom";
 export type OpenAIApiType = "completions" | "responses";
 
 export interface LLMProviderConfig {

--- a/tests/main/ai/llm-router.test.ts
+++ b/tests/main/ai/llm-router.test.ts
@@ -58,6 +58,74 @@ describe("LLMRouter", () => {
   });
 
   describe("routing", () => {
+    it("should route minimax to Anthropic messages endpoint", async () => {
+      const config: LLMProviderConfig = {
+        name: "minimax",
+        baseUrl: "https://api.minimax.io/anthropic/v1",
+        apiKey: "test-minimax-key",
+        model: "MiniMax-M2.7",
+        maxTokens: 4096,
+      };
+      fetchSpy.mockResolvedValueOnce(
+        createJSONResponse({
+          content: [{ type: "text", text: "hello from MiniMax" }],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        }),
+      );
+
+      const router = new LLMRouter(config);
+      await router.complete([{ role: "user", content: "test" }]);
+
+      const [url] = fetchSpy.mock.calls[0];
+      expect(url).toBe("https://api.minimax.io/anthropic/v1/messages");
+    });
+
+    it("should use x-api-key header for minimax", async () => {
+      const config: LLMProviderConfig = {
+        name: "minimax",
+        baseUrl: "https://api.minimax.io/anthropic/v1",
+        apiKey: "test-minimax-key",
+        model: "MiniMax-M2.7",
+        maxTokens: 4096,
+      };
+      fetchSpy.mockResolvedValueOnce(
+        createJSONResponse({
+          content: [{ type: "text", text: "hello" }],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        }),
+      );
+
+      const router = new LLMRouter(config);
+      await router.complete([{ role: "user", content: "test" }]);
+
+      const [, options] = fetchSpy.mock.calls[0];
+      expect(options.headers["x-api-key"]).toBe("test-minimax-key");
+      expect(options.headers).not.toHaveProperty("Authorization");
+    });
+
+    it("should parse MiniMax response content and usage correctly", async () => {
+      const config: LLMProviderConfig = {
+        name: "minimax",
+        baseUrl: "https://api.minimax.io/anthropic/v1",
+        apiKey: "test-minimax-key",
+        model: "MiniMax-M2.7-highspeed",
+        maxTokens: 4096,
+      };
+      fetchSpy.mockResolvedValueOnce(
+        createJSONResponse({
+          content: [{ type: "text", text: "MiniMax response" }],
+          usage: { input_tokens: 20, output_tokens: 10 },
+        }),
+      );
+
+      const router = new LLMRouter(config);
+      const result = await router.complete([{ role: "user", content: "hello" }]);
+
+      expect(result.content).toBe("MiniMax response");
+      expect(result.promptTokens).toBe(20);
+      expect(result.completionTokens).toBe(10);
+    });
+
     it("should route to completions endpoint when apiType is undefined", async () => {
       const config: LLMProviderConfig = { ...baseConfig };
       fetchSpy.mockResolvedValueOnce(


### PR DESCRIPTION
## Summary

- Add MiniMax as a new LLM provider option using the Anthropic-compatible API interface
- Default base URL set to `https://api.minimax.io/anthropic/v1`
- Add MiniMax to provider dropdown in settings UI alongside OpenAI, Anthropic, and Custom
- Add unit tests verifying MiniMax routes to the `/messages` endpoint with correct `x-api-key` authentication

## Supported Models

| Model ID | Description |
|----------|-------------|
| `MiniMax-M2.7` | Peak Performance. Ultimate Value. Master the Complex |
| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile |

## Implementation Details

MiniMax uses the Anthropic-compatible API, which shares the same request format as the existing Anthropic provider (Messages API with `x-api-key` authentication). This means:

- Requests are routed to the `/messages` endpoint
- Authentication uses `x-api-key` header
- Full streaming and agentic loop (tool use) support via the existing Anthropic code path

## API References

- Chat (Anthropic Compatible): https://platform.minimax.io/docs/api-reference/text-anthropic-api

## Configuration

To use MiniMax, select "MiniMax" from the Provider dropdown in Settings and configure:
- **Base URL**: `https://api.minimax.io/anthropic/v1` (default)
- **API Key**: Your MiniMax API key (`MINIMAX_API_KEY`)
- **Model**: `MiniMax-M2.7` or `MiniMax-M2.7-highspeed`