### PR TITLE
fix: improve Linux CA install and decode MITM bodies

### DIFF
--- a/src/main/proxy/cert-installer.ts
+++ b/src/main/proxy/cert-installer.ts
@@ -1,6 +1,6 @@
 import { exec } from "child_process";
+import { existsSync, readFileSync } from "fs";
 import { platform } from "os";
-import { basename } from "path";
 
 /**
  * CertInstaller — Cross-platform CA certificate installation/removal
@@ -8,7 +8,7 @@ import { basename } from "path";
  *
  * Windows: certutil  (UAC prompt via runas)
  * macOS:   security  (password prompt via osascript)
- * Linux:   update-ca-certificates (pkexec/sudo prompt)
+ * Linux:   distro-specific system trust stores (pkexec/sudo prompt)
  */
 
 interface CertResult {
@@ -40,6 +40,28 @@ function sudoExec(cmd: string, name: string): Promise<string> {
   });
 }
 
+async function commandExists(command: string): Promise<boolean> {
+  try {
+    await execPromise(`command -v ${command}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isArchLikeLinux(): boolean {
+  if (existsSync("/etc/arch-release")) return true;
+
+  try {
+    const osRelease = readFileSync("/etc/os-release", "utf-8").toLowerCase();
+    return /(^|\n)id(_like)?=.*\b(arch|manjaro|endeavouros|garuda)\b/.test(
+      osRelease,
+    );
+  } catch {
+    return false;
+  }
+}
+
 export class CertInstaller {
   /**
    * Install CA certificate to the system trust store (requires elevation).
@@ -59,12 +81,7 @@ export class CertInstaller {
           "Anything Analyzer",
         );
       } else {
-        // Linux — copy to ca-certificates dir then update
-        const dest = "/usr/local/share/ca-certificates/anything-analyzer.crt";
-        await sudoExec(
-          `cp "${certPath}" "${dest}" && update-ca-certificates`,
-          "Anything Analyzer",
-        );
+        await this.installLinux(certPath);
       }
 
       return { success: true };
@@ -91,11 +108,7 @@ export class CertInstaller {
           "Anything Analyzer",
         );
       } else {
-        const dest = "/usr/local/share/ca-certificates/anything-analyzer.crt";
-        await sudoExec(
-          `rm -f "${dest}" && update-ca-certificates`,
-          "Anything Analyzer",
-        );
+        await this.uninstallLinux(certPath);
       }
 
       return { success: true };
@@ -122,13 +135,108 @@ export class CertInstaller {
         );
         return out.includes("Anything Analyzer CA");
       } else {
-        const { existsSync } = await import("fs");
-        return existsSync(
-          "/usr/local/share/ca-certificates/anything-analyzer.crt",
-        );
+        return this.isLinuxInstalled();
       }
     } catch {
       return false;
     }
+  }
+
+  private static async installLinux(certPath: string): Promise<void> {
+    if (isArchLikeLinux()) {
+      const dest =
+        "/etc/ca-certificates/trust-source/anchors/anything-analyzer.crt";
+      const refreshCmd = await this.getLinuxTrustRefreshCommand();
+      await sudoExec(
+        `mkdir -p /etc/ca-certificates/trust-source/anchors && cp "${certPath}" "${dest}" && ${refreshCmd}`,
+        "Anything Analyzer",
+      );
+      return;
+    }
+
+    if (await commandExists("update-ca-certificates")) {
+      const dest = "/usr/local/share/ca-certificates/anything-analyzer.crt";
+      await sudoExec(
+        `cp "${certPath}" "${dest}" && update-ca-certificates`,
+        "Anything Analyzer",
+      );
+      return;
+    }
+
+    if (await commandExists("update-ca-trust")) {
+      const dest = "/etc/pki/ca-trust/source/anchors/anything-analyzer.crt";
+      await sudoExec(
+        `mkdir -p /etc/pki/ca-trust/source/anchors && cp "${certPath}" "${dest}" && update-ca-trust extract`,
+        "Anything Analyzer",
+      );
+      return;
+    }
+
+    if (await commandExists("trust")) {
+      await sudoExec(
+        `trust anchor --store "${certPath}" && trust extract-compat`,
+        "Anything Analyzer",
+      );
+      return;
+    }
+
+    throw new Error("No supported Linux CA trust tool found");
+  }
+
+  private static async uninstallLinux(certPath: string): Promise<void> {
+    if (isArchLikeLinux()) {
+      const refreshCmd = await this.getLinuxTrustRefreshCommand();
+      await sudoExec(
+        `rm -f /etc/ca-certificates/trust-source/anchors/anything-analyzer.crt && ${refreshCmd}`,
+        "Anything Analyzer",
+      );
+      return;
+    }
+
+    if (await commandExists("update-ca-certificates")) {
+      await sudoExec(
+        `rm -f /usr/local/share/ca-certificates/anything-analyzer.crt && update-ca-certificates`,
+        "Anything Analyzer",
+      );
+      return;
+    }
+
+    if (await commandExists("update-ca-trust")) {
+      await sudoExec(
+        `rm -f /etc/pki/ca-trust/source/anchors/anything-analyzer.crt && update-ca-trust extract`,
+        "Anything Analyzer",
+      );
+      return;
+    }
+
+    if (await commandExists("trust")) {
+      await sudoExec(
+        `trust anchor --remove "${certPath}" && trust extract-compat`,
+        "Anything Analyzer",
+      );
+      return;
+    }
+
+    throw new Error("No supported Linux CA trust tool found");
+  }
+
+  private static async getLinuxTrustRefreshCommand(): Promise<string> {
+    if (await commandExists("update-ca-trust")) {
+      return "update-ca-trust extract";
+    }
+    if (await commandExists("trust")) {
+      return "trust extract-compat";
+    }
+    throw new Error("No supported Linux CA trust refresh tool found");
+  }
+
+  private static isLinuxInstalled(): boolean {
+    return (
+      existsSync(
+        "/etc/ca-certificates/trust-source/anchors/anything-analyzer.crt",
+      ) ||
+      existsSync("/usr/local/share/ca-certificates/anything-analyzer.crt") ||
+      existsSync("/etc/pki/ca-trust/source/anchors/anything-analyzer.crt")
+    );
   }
 }

--- a/src/main/proxy/mitm-proxy-server.ts
+++ b/src/main/proxy/mitm-proxy-server.ts
@@ -4,6 +4,11 @@ import * as https from "https";
 import * as net from "net";
 import * as tls from "tls";
 import * as url from "url";
+import {
+  brotliDecompressSync,
+  gunzipSync,
+  inflateSync,
+} from "zlib";
 import { v4 as uuidv4 } from "uuid";
 import { SocksClient } from "socks";
 import type { CaManager } from "./ca-manager";
@@ -20,6 +25,43 @@ const BINARY_CONTENT_TYPES = [
   "application/zip",
 ];
 const STATIC_EXTENSIONS = /\.(js|css|png|jpg|jpeg|gif|ico|svg|woff2?|ttf|eot|map)$/i;
+
+function headerToString(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? value.join(",") : value || "";
+}
+
+function decodeCapturedBody(
+  body: Buffer,
+  contentEncoding: string | string[] | undefined,
+): Buffer {
+  const encodings = headerToString(contentEncoding)
+    .toLowerCase()
+    .split(",")
+    .map((encoding) => encoding.trim())
+    .filter(Boolean);
+
+  return encodings.reduceRight((decoded, encoding) => {
+    if (encoding === "br") return brotliDecompressSync(decoded);
+    if (encoding === "gzip" || encoding === "x-gzip") {
+      return gunzipSync(decoded);
+    }
+    if (encoding === "deflate") return inflateSync(decoded);
+    return decoded;
+  }, body);
+}
+
+function bodyToUtf8(
+  body: Buffer,
+  contentEncoding: string | string[] | undefined,
+): string {
+  try {
+    return decodeCapturedBody(body, contentEncoding)
+      .toString("utf-8")
+      .substring(0, MAX_BODY_SIZE);
+  } catch {
+    return body.toString("utf-8").substring(0, MAX_BODY_SIZE);
+  }
+}
 
 /**
  * MitmProxyServer — An embedded HTTP/HTTPS man-in-the-middle proxy.
@@ -615,12 +657,12 @@ export class MitmProxyServer extends EventEmitter {
 
       const requestBody =
         reqBody.length > 0 && !isBinary
-          ? reqBody.toString("utf-8").substring(0, MAX_BODY_SIZE)
+          ? bodyToUtf8(reqBody, clientReq.headers["content-encoding"])
           : null;
 
       const responseBody =
         resBody.length > 0 && !isBinary
-          ? resBody.toString("utf-8").substring(0, MAX_BODY_SIZE)
+          ? bodyToUtf8(resBody, proxyRes.headers["content-encoding"])
           : null;
 
       this.emit("response-captured", {


### PR DESCRIPTION
**Summary**

本次改动修复了 Linux/Arch 环境下 HTTPS MITM 抓包的两个问题：CA 证书安装逻辑不兼容 Arch trust store，以及代理已解密但 br/gzip/deflate 响应体在界面中显示为乱码。

**Changes**

- 为 Linux CA 安装增加发行版适配：
  - Arch/Manjaro/EndeavourOS/Garuda 使用 /etc/ca-certificates/trust-source/anchors/。
  - 支持 update-ca-trust extract 和 trust extract-compat。
  - 保留 Debian 系 update-ca-certificates 路径。
- 修复 MITM 捕获体解码：
  - 捕获入库前解压 br、gzip、x-gzip、deflate。
  - 仅影响存储/展示/分析用 body，不改变转发给客户端的原始响应。
  - 解压失败时回退到原始 UTF-8 转换，避免影响抓包流程。