### PR TITLE
fix: enable dynamic MCP server start/stop without app restart

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -554,6 +554,18 @@ export function registerIpcHandlers(deps: {
 
   ipcMain.handle("mcp-server:saveConfig", async (_event, config: MCPServerSettings) => {
     saveMCPServerConfig(config);
+
+    const { initMCPServer, stopMCPServer, isMCPServerRunning } = await import("./mcp/mcp-server");
+    if (config.enabled && !isMCPServerRunning()) {
+      await initMCPServer(
+        { sessionManager, aiAnalyzer, windowManager, requestsRepo, jsHooksRepo, storageSnapshotsRepo, reportsRepo, interactionEventsRepo },
+        config.port,
+        config.authEnabled,
+        config.authToken,
+      );
+    } else if (!config.enabled && isMCPServerRunning()) {
+      await stopMCPServer();
+    }
   });
 
   ipcMain.handle("mcp-server:status", async () => {

--- a/src/renderer/components/settings/MCPServerSection.tsx
+++ b/src/renderer/components/settings/MCPServerSection.tsx
@@ -125,7 +125,7 @@ export default function MCPServerSection() {
       <Button variant="primary" block onClick={async () => {
         const config: MCPServerSettings = { enabled, port, authEnabled, authToken }
         await window.electronAPI.saveMCPServerConfig(config)
-        toast.success('MCP Server 配置已保存，重启应用后生效')
+        toast.success('MCP Server 配置已保存')
         const status = await window.electronAPI.getMCPServerStatus()
         setRunning(status.running)
       }}>


### PR DESCRIPTION
## Summary

- `mcp-server:saveConfig` handler now dynamically starts/stops the MCP server after saving config, instead of requiring a full app restart
- Follows the same pattern already used by the MITM proxy `saveConfig` handler
- Updated UI toast message to remove "重启应用后生效" since changes now take effect immediately

## Problem

When users enable the MCP Server toggle and click "保存 MCP Server 设置", the config is saved to disk but the server doesn't actually start. The UI shows "已停止" even though `enabled: true`. Users must restart the entire app for the server to start. (See #54)

## Root Cause

The `mcp-server:saveConfig` IPC handler only called `saveMCPServerConfig(config)` without invoking `initMCPServer()`. The MCP server was only initialized once at app startup (`app.whenReady`).

## Fix

Added dynamic start/stop logic to `saveConfig` handler (matching the existing MITM proxy pattern):

```typescript
if (config.enabled && !isMCPServerRunning()) {
  await initMCPServer(...);
} else if (!config.enabled && isMCPServerRunning()) {
  await stopMCPServer();
}
```

Closes #54

