### PR TITLE
feat: trust all self-signed certs and add client certificate selection

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -27,8 +27,19 @@ import { loadMitmProxyConfig, saveMitmProxyConfig } from "./proxy/mitm-proxy-con
 import { SystemProxy } from "./proxy/system-proxy";
 import { ProfileStore } from "./fingerprint/profile-store";
 import { join } from "path";
+import { randomUUID } from "node:crypto";
+
+// Ignore all certificate errors (self-signed, expired, etc.)
+app.commandLine.appendSwitch("ignore-certificate-errors");
+app.commandLine.appendSwitch("ignore-certificate-errors-spki-list");
 
 const windowManager = new WindowManager();
+
+/** Pending client-certificate selections awaiting user choice. */
+const pendingCertSelections = new Map<
+  string,
+  { certificates: Electron.Certificate[]; callback: (cert: Electron.Certificate) => void }
+>();
 const mcpManager = new MCPClientManager();
 let sessionManagerRef: SessionManager | null = null;
 let quitInProgress = false;
@@ -135,6 +146,25 @@ app.whenReady().then(async () => {
     interactionEventsRepo,
   });
 
+  // Client-certificate IPC handlers
+  ipcMain.handle("client-cert:select", (_event, id: string, index: number) => {
+    const pending = pendingCertSelections.get(id);
+    if (!pending) return;
+    const cert = pending.certificates[index];
+    if (cert) {
+      pending.callback(cert);
+    }
+    pendingCertSelections.delete(id);
+  });
+
+  ipcMain.handle("client-cert:cancel", (_event, id: string) => {
+    const pending = pendingCertSelections.get(id);
+    if (pending) {
+      // Not calling callback cancels the connection.
+      pendingCertSelections.delete(id);
+    }
+  });
+
   // Check for updates on startup (non-blocking, delayed 3s)
   setTimeout(() => updater.checkForUpdates(), 3000);
 
@@ -177,15 +207,40 @@ app.whenReady().then(async () => {
       .catch((err) => console.error("[Main] Failed to auto-start MITM proxy:", err));
   }
 
-  // Trust certificates issued by our MITM CA inside Electron.
-  // Without this, HTTPS requests through the MITM proxy fail with SSL errors
-  // that can crash Chromium's network stack (0xC0000005).
-  app.on("certificate-error", (event, _webContents, _url, _error, certificate, callback) => {
-    if (mitmProxy.isRunning() && certificate.issuerName === "Anything Analyzer CA") {
-      event.preventDefault();
-      callback(true);
+  // Trust ALL certificates (self-signed, expired, etc.) — required for analysis scenarios.
+  // This plus the --ignore-certificate-errors switch ensures maximum compatibility.
+  app.on("certificate-error", (event, _webContents, _url, _error, _certificate, callback) => {
+    event.preventDefault();
+    callback(true);
+  });
+
+  // Handle client-certificate selection: forward to renderer for user choice.
+  app.on("select-client-certificate", (event, _webContents, url, list, callback) => {
+    event.preventDefault();
+
+    const id = randomUUID();
+    pendingCertSelections.set(id, { certificates: list, callback });
+
+    const mainWin = windowManager.getMainWindow();
+    if (mainWin && !mainWin.isDestroyed()) {
+      mainWin.webContents.send("client-cert:select", {
+        id,
+        url,
+        certificates: list.map((cert, index) => ({
+          index,
+          issuerName: cert.issuerName,
+          subjectName: cert.subjectName,
+          serialNumber: cert.serialNumber,
+          validStart: cert.validStart,
+          validExpiry: cert.validExpiry,
+        })),
+      });
     } else {
-      callback(false);
+      // No window available — auto-select first certificate as fallback.
+      if (list.length > 0) {
+        callback(list[0]);
+      }
+      pendingCertSelections.delete(id);
     }
   });
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -205,6 +205,26 @@ contextBridge.exposeInMainWorld("electronAPI", {
   openLogFolder: () => ipcRenderer.invoke("log:openFolder"),
   exportLogs: () => ipcRenderer.invoke("log:export"),
 
+  // Client certificate selection
+  selectClientCert: (id: string, index: number) =>
+    ipcRenderer.invoke("client-cert:select", id, index),
+  cancelClientCert: (id: string) =>
+    ipcRenderer.invoke("client-cert:cancel", id),
+  onClientCertSelect: (callback: (data: {
+    id: string;
+    url: string;
+    certificates: Array<{
+      index: number;
+      issuerName: string;
+      subjectName: string;
+      serialNumber: string;
+      validStart: number;
+      validExpiry: number;
+    }>;
+  }) => void) => {
+    ipcRenderer.on("client-cert:select", (_event, data) => callback(data));
+  },
+
   removeAllListeners: (channel: string) => {
     ipcRenderer.removeAllListeners(channel);
   },

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -20,6 +20,7 @@ import { useCapture } from './hooks/useCapture'
 import { useTabs } from './hooks/useTabs'
 import { useConfirm } from './hooks/useConfirm'
 import { useToast } from './ui/Toast'
+import { Modal } from './ui'
 
 import { LocaleProvider } from './i18n'
 import { zh } from './i18n/zh'
@@ -98,6 +99,28 @@ function App(): React.ReactElement {
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Listen for client-certificate selection requests from main process
+  useEffect(() => {
+    const handler = (data: {
+      id: string;
+      url: string;
+      certificates: Array<{
+        index: number;
+        issuerName: string;
+        subjectName: string;
+        serialNumber: string;
+        validStart: number;
+        validExpiry: number;
+      }>;
+    }) => {
+      setClientCertDialog({ open: true, ...data });
+    };
+    window.electronAPI.onClientCertSelect(handler);
+    return () => {
+      window.electronAPI.removeAllListeners('client-cert:select');
+    };
+  }, []);
+
   const openSettings = useCallback(() => {
     setSettingsOpen(true)
     window.electronAPI.setTargetViewVisible(false)
@@ -113,6 +136,21 @@ function App(): React.ReactElement {
   const [selectedRequestId, setSelectedRequestId] = useState<string | null>(null)
   const [selectedSeqs, setSelectedSeqs] = useState<number[]>([])
   const [activeTab, setActiveTab] = useState('requests')
+
+  // Client certificate selection dialog state
+  const [clientCertDialog, setClientCertDialog] = useState<{
+    open: boolean;
+    id: string;
+    url: string;
+    certificates: Array<{
+      index: number;
+      issuerName: string;
+      subjectName: string;
+      serialNumber: string;
+      validStart: number;
+      validExpiry: number;
+    }>;
+  }>({ open: false, id: '', url: '', certificates: [] });
 
   /** Ref to browser placeholder for reporting exact bounds to main process */
   const placeholderRef = useRef<HTMLDivElement>(null)
@@ -252,6 +290,17 @@ function App(): React.ReactElement {
     if (!currentSessionId) return
     await sendFollowUp(currentSessionId, msg)
   }, [currentSessionId, sendFollowUp])
+
+  // Client certificate selection handlers
+  const handleSelectCert = useCallback((index: number) => {
+    window.electronAPI.selectClientCert(clientCertDialog.id, index).catch(() => {});
+    setClientCertDialog(prev => ({ ...prev, open: false }));
+  }, [clientCertDialog.id]);
+
+  const handleCancelCert = useCallback(() => {
+    window.electronAPI.cancelClientCert(clientCertDialog.id).catch(() => {});
+    setClientCertDialog(prev => ({ ...prev, open: false }));
+  }, [clientCertDialog.id]);
 
   // Pill button style for capture controls in browser address bar
   const pillStyle: React.CSSProperties = {
@@ -648,6 +697,78 @@ function App(): React.ReactElement {
       <SettingsModal open={settingsOpen} onClose={closeSettings} currentSessionId={currentSession?.id ?? null} />
       {/* Confirm dialog (portal) */}
       {ConfirmDialog}
+
+      {/* Client certificate selection modal */}
+      <Modal
+        open={clientCertDialog.open}
+        onClose={handleCancelCert}
+        title={t('clientCert.title') || '选择客户端证书'}
+        footer={null}
+        width={560}
+      >
+        <div style={{ color: 'var(--text-secondary)', fontSize: 'var(--font-size-sm)', marginBottom: 16 }}>
+          {(t('clientCert.url') || '网站')}: <code style={{ wordBreak: 'break-all' }}>{clientCertDialog.url}</code>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {clientCertDialog.certificates.length === 0 ? (
+            <div style={{ color: 'var(--text-muted)', padding: '16px 0' }}>
+              {t('clientCert.none') || '没有可用的客户端证书'}
+            </div>
+          ) : (
+            clientCertDialog.certificates.map((cert) => (
+              <button
+                key={cert.index}
+                onClick={() => handleSelectCert(cert.index)}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'flex-start',
+                  gap: 4,
+                  padding: '12px 16px',
+                  borderRadius: 6,
+                  border: '1px solid var(--color-border)',
+                  background: 'var(--color-active)',
+                  cursor: 'pointer',
+                  textAlign: 'left',
+                  width: '100%',
+                  fontFamily: 'var(--font-sans)',
+                  transition: 'border-color 0.15s',
+                }}
+                onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--text-primary)'; }}
+                onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--color-border)'; }}
+              >
+                <span style={{ fontWeight: 600, color: 'var(--text-primary)', fontSize: 'var(--font-size-base)' }}>
+                  {cert.subjectName || cert.serialNumber}
+                </span>
+                <span style={{ color: 'var(--text-muted)', fontSize: 'var(--font-size-2xs)' }}>
+                  {(t('clientCert.issuer') || '颁发者')}: {cert.issuerName || '-'}
+                </span>
+                <span style={{ color: 'var(--text-muted)', fontSize: 'var(--font-size-2xs)' }}>
+                  {(t('clientCert.serial') || '序列号')}: {cert.serialNumber || '-'} |
+                  {' '}{(t('clientCert.valid') || '有效期')}: {new Date(cert.validStart).toLocaleDateString()} - {new Date(cert.validExpiry).toLocaleDateString()}
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 20, gap: 10 }}>
+          <button
+            onClick={handleCancelCert}
+            style={{
+              padding: '6px 16px',
+              borderRadius: 6,
+              border: '1px solid var(--color-border)',
+              background: 'var(--color-active)',
+              color: 'var(--text-secondary)',
+              cursor: 'pointer',
+              fontFamily: 'var(--font-sans)',
+              fontSize: 'var(--font-size-sm)',
+            }}
+          >
+            {t('clientCert.cancel') || '取消'}
+          </button>
+        </div>
+      </Modal>
     </div>
     </LocaleProvider>
   )

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -686,6 +686,22 @@ export interface ElectronAPI {
   getLogPath: () => Promise<string>;
   openLogFolder: () => Promise<void>;
   exportLogs: () => Promise<boolean>;
+
+  // Client certificate selection
+  selectClientCert: (id: string, index: number) => Promise<void>;
+  cancelClientCert: (id: string) => Promise<void>;
+  onClientCertSelect: (callback: (data: {
+    id: string;
+    url: string;
+    certificates: Array<{
+      index: number;
+      issuerName: string;
+      subjectName: string;
+      serialNumber: string;
+      validStart: number;
+      validExpiry: number;
+    }>;
+  }) => void) => void;
 }
 
 declare global {


### PR DESCRIPTION
- Enable --ignore-certificate-errors for embedded browser
- Trust all certificates (self-signed, expired, etc.)
- Add select-client-certificate support with UI dialog