### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/src/renderer/components/settings/LLMSection.tsx
+++ b/src/renderer/components/settings/LLMSection.tsx
@@ -125,7 +125,7 @@ export default function LLMSection() {
         <Input
           value={model}
           onChange={e => setModel(e.target.value)}
-          placeholder="gpt-4o / claude-sonnet-4-20250514 / MiniMax-M2.7 / ..."
+          placeholder="gpt-4o / claude-sonnet-4-20250514 / MiniMax-M3 / ..."
         />
       </div>
 

--- a/tests/main/ai/llm-router.test.ts
+++ b/tests/main/ai/llm-router.test.ts
@@ -77,7 +77,7 @@ describe("LLMRouter", () => {
         name: "minimax",
         baseUrl: "https://api.minimax.io/anthropic/v1",
         apiKey: "test-minimax-key",
-        model: "MiniMax-M2.7",
+        model: "MiniMax-M3",
         maxTokens: 4096,
       };
       fetchSpy.mockResolvedValueOnce(
@@ -99,7 +99,7 @@ describe("LLMRouter", () => {
         name: "minimax",
         baseUrl: "https://api.minimax.io/anthropic/v1",
         apiKey: "test-minimax-key",
-        model: "MiniMax-M2.7",
+        model: "MiniMax-M3",
         maxTokens: 4096,
       };
       fetchSpy.mockResolvedValueOnce(
@@ -442,7 +442,7 @@ describe("LLMRouter", () => {
         name: "minimax",
         baseUrl: "https://api.minimax.io/anthropic/v1",
         apiKey: "test-minimax-key",
-        model: "MiniMax-M2.7",
+        model: "MiniMax-M3",
         maxTokens: 4096,
       };
       fetchSpy.mockResolvedValueOnce(
@@ -465,7 +465,7 @@ describe("LLMRouter", () => {
         name: "minimax",
         baseUrl: "https://api.minimax.io/anthropic/v1",
         apiKey: "test-minimax-key",
-        model: "MiniMax-M2.7",
+        model: "MiniMax-M3",
         maxTokens: 4096,
       };
       fetchSpy.mockResolvedValueOnce(


### PR DESCRIPTION
## Summary
Refresh the MiniMax model references to point at the new flagship `MiniMax-M3`. Since the project takes the model name as free-text input rather than a model list, this PR updates only the user-facing placeholder hint and the test fixtures that drive the MiniMax routing tests.

## Changes
- `src/renderer/components/settings/LLMSection.tsx`: Update the model input placeholder from `MiniMax-M2.7` to `MiniMax-M3` so new users see the latest model as the suggested example.
- `tests/main/ai/llm-router.test.ts`: Update four `MiniMax-M2.7` fixtures to `MiniMax-M3`. The `MiniMax-M2.7-highspeed` fixture is intentionally kept to preserve coverage for the highspeed variant, which is still available on the platform.

## Why
`MiniMax-M3` is the new flagship model with a 512K context window, 128K max output, and image input support across both OpenAI-compatible and Anthropic-compatible interfaces. Surfacing it as the placeholder example makes the recommended default obvious for new users while keeping all existing free-text model names usable.

## Testing
- `pnpm test` — 63 tests passing (3 skipped), including all minimax routing/header/parsing cases
- `npx tsc --noEmit` — no type errors