### PR TITLE
fix(settings): support Max Tokens values up to 1M

### DIFF
--- a/src/renderer/components/settings/LLMSection.tsx
+++ b/src/renderer/components/settings/LLMSection.tsx
@@ -135,7 +135,7 @@ export default function LLMSection() {
           value={maxTokens}
           onChange={v => v !== null && setMaxTokens(v)}
           min={256}
-          max={128000}
+          max={1000000}
           style={{ width: '100%' }}
         />
       </div>


### PR DESCRIPTION
## Summary

Adjust the Max Tokens setting limit from 128,000 to 1,000,000 so providers and models that support larger output limits can be configured from the settings page.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm test` (113 passed, 3 skipped)

Thank you for considering this small compatibility improvement.